### PR TITLE
Feat/NEWCLICKUI-4391 add new rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,7 @@ const checkTypography = (rule, result, context, ruleName) => {
     }
 };
 
-const checkDarkColorsUsage = (decl, result, context, ruleName) => {
+const checkDarkColorsUsage = (decl, result) => {
     const { prop, raws } = decl;
 
     let value = toOneLine(decl.value);

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ const RULE_USE_MIXINS = 'stylelint-core-vars/use-mixins';
 const RULE_USE_ONE_OF_MIXINS = 'stylelint-core-vars/use-one-of-mixins';
 const RULE_DO_NOT_USE_DARK_COLORS = 'stylelint-core-vars/do-not-use-dark-colors';
 const RULE_DO_NOT_USE_OLD_VARS = 'stylelint-core-vars/do-not-use-old-vars';
+const RULE_NO_USELESS_VARS_IMPORT = 'stylelint-core-vars/no-useless-vars-import';
 
 const messages = {
     [RULE_USE_VARS]: stylelint.utils.ruleMessages(RULE_USE_VARS, {
@@ -59,6 +60,11 @@ const messages = {
             return 'Do not use dark colors directly. Only light and static colors are allowed';
         },
     }),
+    [RULE_NO_USELESS_VARS_IMPORT]: stylelint.utils.ruleMessages(RULE_NO_USELESS_VARS_IMPORT, {
+        expected: () => {
+            return 'Do not import vars.css unless you use a @mixin or @include';
+        },
+    }),
 };
 
 const checkVars = (decl, result, context, ruleName, matcher, shouldReport, options = {}) => {
@@ -81,7 +87,7 @@ const checkVars = (decl, result, context, ruleName, matcher, shouldReport, optio
 
         const originalValueIndex = previousValues.reduce(
             (acc, sub) => (acc > sub.index + sub.diff ? acc - sub.diff : acc),
-            substitution.index
+            substitution.index,
         );
 
         if (shouldReport(substitution.fixable, fixed)) {
@@ -91,7 +97,7 @@ const checkVars = (decl, result, context, ruleName, matcher, shouldReport, optio
                 message: messages[ruleName].expected(
                     substitution.variables,
                     substitution.value,
-                    substitution.fixable
+                    substitution.fixable,
                 ),
                 node: decl,
                 word: value,
@@ -174,6 +180,46 @@ const checkDarkColorsUsage = (decl, result, context, ruleName) => {
     }
 };
 
+const checkVarsImportUsage = (root, result, context, ruleName) => {
+    const isVarsCssImport = (params) => /\/?vars\.css(['"])?\s*;?$/.test(params);
+
+    let hasVarsImport = false;
+    let usesMixinOrInclude = false;
+    const importNodes = [];
+
+    root.walkAtRules((atRule) => {
+        if (atRule.name === 'import' && isVarsCssImport(atRule.params)) {
+            hasVarsImport = true;
+            importNodes.push(atRule);
+        }
+
+        if (
+            atRule.name === 'mixin' ||
+            atRule.name === 'include' ||
+            (atRule.name === 'use' && /mixin/.test(atRule.params))
+        ) {
+            usesMixinOrInclude = true;
+        }
+    });
+
+    if (hasVarsImport && !usesMixinOrInclude) {
+        importNodes.forEach((atRule) => {
+            if (context.fix) {
+                atRule.remove();
+            } else {
+                stylelint.utils.report({
+                    result,
+                    ruleName,
+                    message: messages[RULE_NO_USELESS_VARS_IMPORT].expected(),
+                    node: atRule,
+                    word: 'vars.css',
+                    index: atRule.params.indexOf('vars.css'),
+                });
+            }
+        });
+    }
+};
+
 module.exports = [
     stylelint.createPlugin(RULE_USE_VARS, (enabled, config, context) => {
         if (!enabled || !VARS_AVAILABLE) {
@@ -191,7 +237,7 @@ module.exports = [
                     RULE_USE_VARS,
                     findVars,
                     (fixable, fixed) => fixable && !fixed,
-                    { allowNumericValues }
+                    { allowNumericValues },
                 );
             });
         };
@@ -212,7 +258,7 @@ module.exports = [
                     RULE_USE_ONE_OF_VARS,
                     findVars,
                     (fixable, fixed) => !fixable && !fixed,
-                    { allowNumericValues }
+                    { allowNumericValues },
                 );
             });
         };
@@ -230,7 +276,7 @@ module.exports = [
                     context,
                     RULE_DO_NOT_USE_OLD_VARS,
                     findOldVars,
-                    (_, fixed) => !fixed
+                    (_, fixed) => !fixed,
                 );
             });
         };
@@ -268,6 +314,15 @@ module.exports = [
             });
         };
     }),
+    stylelint.createPlugin(RULE_NO_USELESS_VARS_IMPORT, (enabled, _, context) => {
+        if (!enabled || !VARS_AVAILABLE) {
+            return () => {};
+        }
+
+        return (root, result) => {
+            checkVarsImportUsage(root, result, context, RULE_NO_USELESS_VARS_IMPORT);
+        };
+    }),
 ];
 
 module.exports.messages = messages;
@@ -277,3 +332,4 @@ module.exports.RULE_USE_MIXINS = RULE_USE_MIXINS;
 module.exports.RULE_USE_ONE_OF_MIXINS = RULE_USE_ONE_OF_MIXINS;
 module.exports.RULE_DO_NOT_USE_DARK_COLORS = RULE_DO_NOT_USE_DARK_COLORS;
 module.exports.RULE_DO_NOT_USE_OLD_VARS = RULE_DO_NOT_USE_OLD_VARS;
+module.exports.RULE_NO_USELESS_VARS_IMPORT = RULE_NO_USELESS_VARS_IMPORT;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,6 +7,7 @@ const {
     RULE_USE_ONE_OF_MIXINS,
     RULE_DO_NOT_USE_DARK_COLORS,
     RULE_DO_NOT_USE_OLD_VARS,
+    RULE_NO_USELESS_VARS_IMPORT,
     messages,
 } = require('../lib');
 
@@ -181,7 +182,7 @@ testRule({
             description: 'hardcode singleline shadow',
             message: messages[RULE_USE_VARS].expected(
                 ['--shadow-xs'],
-                '0 0 4px rgba(11, 31, 53, 0.02), 0 2px 4px rgba(11, 31, 53, 0.04)'
+                '0 0 4px rgba(11, 31, 53, 0.02), 0 2px 4px rgba(11, 31, 53, 0.04)',
             ),
             line: 2,
             column: 17,
@@ -193,7 +194,7 @@ testRule({
             description: 'hardcode multiline shadow',
             message: messages[RULE_USE_VARS].expected(
                 ['--shadow-xs-hard'],
-                '0 0 4px rgba(11, 31, 53, 0.02), 0 2px 4px rgba(11, 31, 53, 0.04), 0 2px 4px rgba(11, 31, 53, 0.16)'
+                '0 0 4px rgba(11, 31, 53, 0.02), 0 2px 4px rgba(11, 31, 53, 0.04), 0 2px 4px rgba(11, 31, 53, 0.16)',
             ),
             line: 2,
             column: 17,
@@ -219,7 +220,7 @@ testRule({
                 {
                     message: messages[RULE_USE_VARS].expected(
                         ['--shadow-xs'],
-                        '0 0 4px rgba(11, 31, 53, 0.02), 0 2px 4px rgba(11, 31, 53, 0.04)'
+                        '0 0 4px rgba(11, 31, 53, 0.02), 0 2px 4px rgba(11, 31, 53, 0.04)',
                     ),
                     line: 3,
                     column: 17,
@@ -429,7 +430,7 @@ testRule({
                             '--color-light-specialbg-secondary-grouped',
                             '--color-light-graphic-primary-inverted',
                         ],
-                        '#fff'
+                        '#fff',
                     ),
                 },
                 {
@@ -441,7 +442,7 @@ testRule({
                             '--color-light-specialbg-secondary-grouped',
                             '--color-light-graphic-primary-inverted',
                         ],
-                        '#fff'
+                        '#fff',
                     ),
                 },
                 {
@@ -453,7 +454,7 @@ testRule({
                             '--color-light-graphic-primary',
                             '--color-light-bg-primary-inverted',
                         ],
-                        '#0b1f35'
+                        '#0b1f35',
                     ),
                 },
             ],
@@ -485,7 +486,7 @@ testRule({
                             '--color-light-specialbg-secondary-grouped',
                             '--color-light-graphic-primary-inverted',
                         ],
-                        '#fff'
+                        '#fff',
                     ),
                 },
                 {
@@ -497,7 +498,7 @@ testRule({
                             '--color-light-specialbg-secondary-grouped',
                             '--color-light-graphic-primary-inverted',
                         ],
-                        '#fff'
+                        '#fff',
                     ),
                 },
                 {
@@ -509,7 +510,7 @@ testRule({
                             '--color-light-graphic-primary',
                             '--color-light-bg-primary-inverted',
                         ],
-                        '#0b1f35'
+                        '#0b1f35',
                     ),
                 },
             ],
@@ -544,7 +545,7 @@ testRule({
             fixed: `.class {\n    background-color: var(--color-light-bg-tertiary);\n}`,
             message: messages[RULE_DO_NOT_USE_OLD_VARS].expected(
                 ['--color-light-bg-tertiary'],
-                '--color-dark-indigo-10-flat'
+                '--color-dark-indigo-10-flat',
             ),
             line: 2,
             column: 27,
@@ -576,7 +577,7 @@ testRule({
                     message: messages[RULE_DO_NOT_USE_OLD_VARS].expected(
                         ['--color-light-bg-negative-muted'],
                         '--color-red-brand-10-flat',
-                        false
+                        false,
                     ),
                 },
                 {
@@ -585,7 +586,7 @@ testRule({
                     message: messages[RULE_DO_NOT_USE_OLD_VARS].expected(
                         ['--color-light-graphic-negative'],
                         '--color-red-dark',
-                        true
+                        true,
                     ),
                 },
             ],
@@ -856,6 +857,43 @@ testRule({
                     message: messages[RULE_DO_NOT_USE_DARK_COLORS].expected(),
                 },
             ],
+        },
+    ],
+});
+
+testRule({
+    plugins: [RULE_NO_USELESS_VARS_IMPORT],
+    ruleName: RULE_NO_USELESS_VARS_IMPORT,
+    config: true,
+    accept: [
+        {
+            code: `@import '../../../shared/styles/vars.css';\n.css { @include flex-center; }`,
+            description: 'mixin in use',
+        },
+        {
+            code: `.class { padding: 8px; }`,
+            description: 'not have import',
+        },
+        {
+            code: `
+            /* stylelint-disable */
+            @import '../../../shared/styles/vars.css';
+
+            .class {
+                font-size: 48px;
+            }
+            `,
+            description: 'linter disabled',
+        },
+    ],
+    reject: [
+        {
+            code: `@import '../../../shared/styles/vars.css';\n.class { color: red; }`,
+            description: 'without using mixin/include',
+            message: messages[RULE_NO_USELESS_VARS_IMPORT].expected(),
+            line: 1,
+            column: 25,
+            fixed: `.class { color: red; }`,
         },
     ],
 });


### PR DESCRIPTION
Добавлено правило, которое запрещает импорт vars.css в проектах.
Учтено использование вместе с `@mixin / @include `. 

checkDarkColorsUsage() - убраны неиспользуемые параметры.

## Мотивация и контекст
Выполнено в рамках задачи - **NEWCLICKUI-4391** "Нужно запретить импорт @import '../../vars.css' в css-модулях". 
Для модулей, в которых есть миксины, импорт разрешаем